### PR TITLE
addendum: fix swf path (2)

### DIFF
--- a/ssnm/settings_production.py
+++ b/ssnm/settings_production.py
@@ -10,7 +10,8 @@ locals().update(
         STATIC_ROOT=STATIC_ROOT,
     ))
 
-# flash component location
+# Flash components are served off the local server
+MEDIA_URL = '/flash/'
 MEDIA_ROOT = "/var/www/ssnm/ssnm/flash/"
 
 try:

--- a/ssnm/settings_staging.py
+++ b/ssnm/settings_staging.py
@@ -10,7 +10,8 @@ locals().update(
         INSTALLED_APPS=INSTALLED_APPS,
     ))
 
-# flash component location
+# Flash components are served off the local server
+MEDIA_URL = '/flash/'
 MEDIA_ROOT = "/var/www/ssnm/ssnm/flash/"
 
 try:

--- a/ssnm/templates/map_view.html
+++ b/ssnm/templates/map_view.html
@@ -18,7 +18,7 @@
   codebase="http://fpdownload.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=6,0,0,0"
    width="685px" height="470px" align="middle" >
         <param name="allowScriptAccess" value="sameDomain" />
-        <param name="movie" value="/flash/ecomap.swf" />
+        <param name="movie" value="{{MEDIA_URL}}ecomap.swf" />
         <param name="loop" value="false" />
         <param name="menu" value="false" />
         <param name="quality" value="high" />
@@ -27,7 +27,7 @@
         <param name="bgcolor" value="#ffffff" />
         <param  name="flashvars" value="server=/ecomap/{{map.id}}/display/&amp;returnPath=back_to_list_button_clicked" />
             <embed
-            src="/flash/ecomap.swf"
+            src="{{MEDIA_URL}}ecomap.swf"
             loop="false" menu="false"
             quality="high" 
             scale="noscale" 


### PR DESCRIPTION
okay, pr (https://github.com/ccnmtl/ssnm/pull/188) fixed the issue. But, this should make it all clearer.

The ccnmtlsettings update inadvertently overrode the MEDIA_URL in settings_shared -- which should be /flash/. Restoring 'MEDIA_URL' references in map_view.html and fixing the settings_staging/settings_production to reflect the correct MEDIA_URL.