### PR TITLE
Remove migration_modules overrides

### DIFF
--- a/ssnm/settings_shared.py
+++ b/ssnm/settings_shared.py
@@ -26,10 +26,6 @@ INSTALLED_APPS += [  # noqa
 
 REGISTRATION_APPLICATION_MODEL = 'registration.Application'
 
-MIGRATION_MODULES = {
-    'registration': 'ssnm.migrations.registration',
-}
-
 ACCOUNT_ACTIVATION_DAYS = 1
 
 INTERNAL_IPS = ('127.0.0.1', )


### PR DESCRIPTION
The registration module migrations should be pulled from the library directly.

Note: this pull request will likely fail for staging & production.
The command `./manage.py migrate --settings=ssnm.settings_<env> registration --fake-initial` might need to be run manually in those environments. I'm happy to usher it through once the merge is complete.
