### PR TITLE
Logout page for local users

### DIFF
--- a/ssnm/templates/base.html
+++ b/ssnm/templates/base.html
@@ -28,7 +28,7 @@
             {% if request.user.is_anonymous %}
                 <a href="/accounts/login/?next=/">Log in</a>
             {% else %}
-                <a href="/logout/">Log out</a>
+                <a href="/accounts/logout/?next=/">Log out</a>
             {% endif %}
             </li>
         {% endblock %}


### PR DESCRIPTION
Send local users back to the home page on logout. The existing behavior sends them to the admin logout page.